### PR TITLE
Makefile: Make Compiler Configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
+ifeq ($(origin CC),default)
 CC=gcc
+endif
 # Enable all compiler warnings. 
 CCFLAGS=-g -Wall -fPIC -Werror -std=gnu99
 # Linker flags


### PR DESCRIPTION
Make CC variable and therefore the compiler configurable by checking if
it is set already by using the origin function.
This is helpful to change the compiler version on the fly or to use a
specific compiler for a different platform.

Signed-off-by: Jens Erdmann <jens.erdmann@web.de>